### PR TITLE
Enforce 7-day Minimum Release Age for Dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
    "@sentry/cli": true
    sharp: true
+minimumReleaseAge: 10080

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
    ],
    "rangeStrategy": "pin",
    "schedule": ["every weekend"],
-   "timezone": "America/Los_Angeles"
+   "timezone": "America/Los_Angeles",
+   "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge: 10080` (minutes = 7 days) in `pnpm-workspace.yaml` so pnpm refuses to install package versions newer than 7 days at install time.
- Set `"minimumReleaseAge": "7 days"` in `renovate.json` so Renovate holds back PRs until a release is at least 7 days old.

Defense-in-depth against supply chain attacks: Renovate won't open PRs for fresh releases, and pnpm enforces the same window even if a new version sneaks in via manual edits or transitive range resolution.

## Test plan
- [ ] Confirm `pnpm install --frozen-lockfile` still succeeds locally (no warnings about unknown setting).
- [ ] Wait for the next Renovate run and confirm PRs only appear for versions ≥ 7 days old.