### PR TITLE
perf(images): set image cache TTL to 1 year

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,6 +13,7 @@ const nextConfig = {
             hostname: "media.masonmcelvain.com",
          },
       ],
+      minimumCacheTTL: 31536000,
    },
 };
 


### PR DESCRIPTION
Override Next.js's 4-hour default minimumCacheTTL so optimized variants of immutable R2 blog images aren't re-transformed and re-written every few hours, sharply reducing Vercel image cache write usage.

https://vercel.com/docs/image-optimization/managing-image-optimization-costs#reducing-usage