### PR TITLE
Blog heading links

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import rehypeSlug from "rehype-slug";
 import { getPostBySlug, getAllPostSlugs } from "@/lib/posts";
 import { extractToc } from "@/lib/toc";
+import { headingLinkComponents } from "@/components/HeadingLink";
 import { ImageCarousel } from "@/components/ImageCarousel";
 import { ImageWithCaption } from "@/components/ImageWithCaption";
 import { TableOfContents } from "@/components/TableOfContents";
@@ -10,6 +11,7 @@ import { VideoWithCaption } from "@/components/VideoWithCaption";
 import type { Metadata } from "next";
 
 const mdxComponents = {
+   ...headingLinkComponents,
    ImageCarousel,
    ImageWithCaption,
    VideoWithCaption,

--- a/components/HeadingLink.tsx
+++ b/components/HeadingLink.tsx
@@ -1,0 +1,33 @@
+import { type ComponentPropsWithoutRef } from "react";
+
+type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+type HeadingProps = ComponentPropsWithoutRef<"h2">;
+
+function headingLink(Tag: HeadingTag) {
+   function Heading({ id, children, ...props }: HeadingProps) {
+      if (!id) {
+         return <Tag {...props}>{children}</Tag>;
+      }
+      return (
+         <Tag id={id} {...props}>
+            <a
+               href={`#${id}`}
+               className="not-prose no-underline hover:underline"
+            >
+               {children}
+            </a>
+         </Tag>
+      );
+   }
+   Heading.displayName = `HeadingLink(${Tag})`;
+   return Heading;
+}
+
+export const headingLinkComponents = {
+   h1: headingLink("h1"),
+   h2: headingLink("h2"),
+   h3: headingLink("h3"),
+   h4: headingLink("h4"),
+   h5: headingLink("h5"),
+   h6: headingLink("h6"),
+};


### PR DESCRIPTION
Wraps a heading's text in a self link so readers can grab a URL for any section. rehype-slug supplies the id, the same one the table of contents links to. `not-prose` keeps the typography plugin's link color and underline off the anchor, so it inherits the heading's own styles and looks unchanged until hover.